### PR TITLE
Add optional support for relative Python paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,3 +124,11 @@ nnoremap <Leader>rp :PythonCopyReferencePytest<CR>
 Usage
 -----
 Just place the cursor anywhere in the line with your target class/method/function name. Once you pressed your mappings, the reference will be copied in the system clipboard. Then, you could paste it anywhere.
+
+Testing
+-------
+This project uses [Vader](https://github.com/junegunn/vader.vim) to run the tests. After installing Vader, run the tests like this:
+
+```bash
+vim -c 'Vader! test/*'
+```

--- a/autoload/python_copy_reference.vim
+++ b/autoload/python_copy_reference.vim
@@ -1,3 +1,5 @@
+let g:python_copy_reference = get(g:, 'python_copy_reference', {})
+
 function! python_copy_reference#_jump_to_parent()
     " Specialized version of `Python_jump`:
     " https://github.com/vim/vim/blob/v8.2.5172/runtime/ftplugin/python.vim#L88
@@ -29,10 +31,10 @@ endfunction
 
 function! python_copy_reference#_get_reference(path_format, separator)
     let file_path = expand(a:path_format)
-    let reference = file_path
+    let reference = python_copy_reference#_relative_path(file_path)
 
     if a:separator == '.'
-        let reference = substitute(file_path, '\/', a:separator, 'g')
+        let reference = substitute(reference, '\/', a:separator, 'g')
     endif
 
     let current_word = expand('<cword>')
@@ -56,6 +58,22 @@ function! python_copy_reference#_get_reference(path_format, separator)
         " Return the file path + function/class + inner function/class/method.
         return reference . a:separator . parent_name . a:separator . name
     endif
+endfunction
+
+function! python_copy_reference#_relative_path(reference)
+  if !has_key(g:python_copy_reference, 'paths')
+    return reference
+  endif
+
+  for path in g:python_copy_reference['paths']
+    let pattern = '^' . path . '/'
+
+    if match(a:reference, pattern) == 0
+      return substitute(a:reference, pattern, "", "g")
+    endif
+  endfor
+
+  return a:reference
 endfunction
 
 


### PR DESCRIPTION
Great little script ⭐

I have a suggestion for supporting Python paths, which is useful when copying a reference to use later on as an import in the Python shell (possibly with some minor edits) e.g.

```
# src/path/to/file.py
def some_function(): pass

# python shell
from path.to.file import some_function
```

This adds an optional global list of "paths" to substitute before the other substitutions. I thought it would be useful to add a test since this increases the complexity of the script a bit.

Approach
========

This change adds knowledge of the Python environment to the plugin, which may not be robust as paths change depending on the project. On the other hand, many paths should work generally e.g. "src".

An alternative option would be to decouple getting the reference and copying it to the clipboard, which would allow people like me to get the reference and perform whatever substitutions they like on it*.

\*I appreciate I could also just grab it from the clipboard, change it, and overwrite the clipboard.