### PR TITLE
Introduce new "from ... import ..." reference format

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,35 @@ Assuming that we have `apps/foo/bar.py` file with the given codes. The commented
             pass
     ```
 
+- Import Format
+    ```python
+    """
+    Default value (elsewhere in the file):
+    from apps.foo import bar
+    """
+
+    # from app.foo.bar import function_1
+    def function_1():
+        pass
+
+    # from apps.foo.bar import Baz
+    class Baz():
+
+        # from apps.foo import bar
+        class Meta:
+            pass
+
+        # from apps.foo import bar
+        def method_1(self):
+            pass
+
+    ```
+
 For example, when the cursor is placed anywhere in this line:
 
 `def method_1(self):`
 
-Then, the copied reference will be `apps.foo.bar.Baz.method_1` (or `apps/foo/bar.py::Baz::method_1` depending on the command you invoked) which could be used to run the that specific test (assuming it is a test case/method). Likewise, a message will be displayed in the status line for better UX:
+Then, the copied reference will be `apps.foo.bar.Baz.method_1` (for the Dotted format), which could be used to run the that specific test (assuming it is a test case/method). Likewise, a message will be displayed in the status line for better UX:
 
 `Copied reference: apps.foo.bar.Baz.method_1`
 
@@ -118,6 +142,7 @@ There are no default mappings, but could easily create them. For example:
 ```
 nnoremap <Leader>rd :PythonCopyReferenceDotted<CR>
 nnoremap <Leader>rp :PythonCopyReferencePytest<CR>
+nnoremap <Leader>ri :PythonCopyReferenceImport<CR>
 ```
 
 

--- a/autoload/python_copy_reference.vim
+++ b/autoload/python_copy_reference.vim
@@ -62,20 +62,20 @@ function! python_copy_reference#_get_reference(path_format, separator, allow_nes
     endif
 endfunction
 
-function! python_copy_reference#_remove_prefixes(reference)
+function! python_copy_reference#_remove_prefixes(file_path)
   if !has_key(g:python_copy_reference, 'remove_prefixes')
-    return a:reference
+    return a:file_path
   endif
 
   for path in g:python_copy_reference['remove_prefixes']
     let pattern = '^' . path . '/'
 
-    if match(a:reference, pattern) == 0
-      return substitute(a:reference, pattern, "", "g")
+    if match(a:file_path, pattern) == 0
+      return substitute(a:file_path, pattern, "", "g")
     endif
   endfor
 
-  return a:reference
+  return a:file_path
 endfunction
 
 

--- a/autoload/python_copy_reference.vim
+++ b/autoload/python_copy_reference.vim
@@ -83,7 +83,7 @@ function! python_copy_reference#_remove_prefixes(file_path)
 endfunction
 
 
-function! python_copy_reference#_copy_reference(format)
+function! python_copy_reference#_get_reference(format)
     " Mark the current cursor/column location.
     " Use `X` instead of `x` to minimize collision with user's marks.
     execute 'normal! mX'
@@ -113,31 +113,33 @@ function! python_copy_reference#_copy_reference(format)
     let attribute_parts = python_copy_reference#_get_attribute_parts(allow_nested)
     let reference = join([module] + attribute_parts, separator)
 
-    if a:format == 'import'
-        " Convert 'x.y.z' into 'x.y import z'
-        let reference = substitute(reference, '^\(.*\)\.\([^.]*\)$', '\1 import \2', 'g')
-        let reference = 'from ' . reference
-    endif
-
-    " Copy to system clipboard.
-    echomsg 'Copied reference: ' . reference
-    let @+ = reference
-
     " Go back to marked/initial cursor for better UX.
     execute 'normal! `X'
+
+    return reference
 endfunction
 
 
 function! python_copy_reference#dotted()
-    call python_copy_reference#_copy_reference('dotted')
+    let reference = python_copy_reference#_get_reference('dotted')
+    echomsg 'Copied reference: ' . reference
+    let @+ = reference
 endfunction
 
 
 function! python_copy_reference#pytest()
-    call python_copy_reference#_copy_reference('pytest')
+    let reference = python_copy_reference#_get_reference('pytest')
+    echomsg 'Copied reference: ' . reference
+    let @+ = reference
 endfunction
 
 
 function! python_copy_reference#import()
-    call python_copy_reference#_copy_reference('import')
+    let reference = python_copy_reference#_get_reference('import')
+    " Convert 'x.y.z' into 'x.y import z'
+    let reference = substitute(reference, '^\(.*\)\.\([^.]*\)$', '\1 import \2', 'g')
+    let reference = 'from ' . reference
+    " Copy to system clipboard.
+    echomsg 'Copied reference: ' . reference
+    let @+ = reference
 endfunction

--- a/plugin/python-copy-reference.vim
+++ b/plugin/python-copy-reference.vim
@@ -14,3 +14,4 @@ let g:loaded_python_copy_reference = 1
 " Exposes the plugin's functions for use as commands in Vim.
 command! -nargs=0 PythonCopyReferenceDotted call python_copy_reference#dotted()
 command! -nargs=0 PythonCopyReferencePytest call python_copy_reference#pytest()
+command! -nargs=0 PythonCopyReferenceImport call python_copy_reference#import()

--- a/test/attribute.vader
+++ b/test/attribute.vader
@@ -1,0 +1,15 @@
+Do (copy reference):
+  :e! some/package/path.py\<cr>
+  idef SomeClass():\<cr>  def some_function():\<cr>    pass\<esc>
+  k
+  :let g:python_copy_reference = {}\<cr>
+  :call python_copy_reference#dotted()\<cr>
+
+Do (paste reference):
+  "+p
+
+Expect:
+  some.package.path.SomeClass.some_function
+
+Do (clean up):
+  :%bd!\<cr>

--- a/test/dotted.vader
+++ b/test/dotted.vader
@@ -1,5 +1,5 @@
 Do (copy reference):
-  :e some/package/path.py\<cr>
+  :e! some/package/path.py\<cr>
   :let g:python_copy_reference = {}\<cr>
   :call python_copy_reference#dotted()\<cr>
 
@@ -8,3 +8,6 @@ Do (paste reference):
 
 Expect:
   some.package.path
+
+Do (clean up):
+  :%bd!\<cr>

--- a/test/import.vader
+++ b/test/import.vader
@@ -1,0 +1,13 @@
+Do (copy reference):
+  :e! some/package/path.py\<cr>
+  :let g:python_copy_reference = {}\<cr>
+  :call python_copy_reference#import()\<cr>
+
+Do (paste reference):
+  "+p
+
+Expect:
+  from some.package import path
+
+Do (clean up):
+  :%bd!\<cr>

--- a/test/pytest.vader
+++ b/test/pytest.vader
@@ -1,5 +1,5 @@
 Do (copy reference):
-  :e some/package/path.py\<cr>
+  :e! some/package/path.py\<cr>
   :let g:python_copy_reference = {}\<cr>
   :call python_copy_reference#pytest()\<cr>
 
@@ -8,3 +8,6 @@ Do (paste reference):
 
 Expect:
   some/package/path.py
+
+Do (clean up):
+  :%bd!\<cr>

--- a/test/pytest.vader
+++ b/test/pytest.vader
@@ -1,0 +1,10 @@
+Do (copy reference):
+  :e some/package/path.py\<cr>
+  :let g:python_copy_reference = {}\<cr>
+  :call python_copy_reference#pytest()\<cr>
+
+Do (paste reference):
+  "+p
+
+Expect:
+  some/package/path.py

--- a/test/relative.vader
+++ b/test/relative.vader
@@ -1,5 +1,5 @@
 Do (copy reference):
-  :e some/package/path.py\<cr>
+  :e! some/package/path.py\<cr>
   :let g:python_copy_reference = {'remove_prefixes': ['some']}\<cr>
   :call python_copy_reference#dotted()\<cr>
 
@@ -8,3 +8,6 @@ Do (paste reference):
 
 Expect:
   package.path
+
+Do (clean up):
+  :%bd!\<cr>


### PR DESCRIPTION
This can be used to speed up importing attributes:

- When writing code in other files.

- When hacking code in a REPL tool.

Since the new feature increased the complexity of some of 
the existing functions, I've added a few extra commits with 
refactorings to try and make the code a bit simpler again.

Please review commit by commit.