### PR TITLE
Fix using absolute path when files opened this way

### DIFF
--- a/autoload/python_copy_reference.vim
+++ b/autoload/python_copy_reference.vim
@@ -31,6 +31,8 @@ endfunction
 
 function! python_copy_reference#_get_module(path_format, separator)
     let file_path = expand(a:path_format)
+    " Truncate files opened with full paths using CWD.
+    let file_path = fnamemodify(file_path, ":.")
     let module = python_copy_reference#_remove_prefixes(file_path)
 
     if a:separator == '.'


### PR DESCRIPTION
This is an issue I've encountered when using this plugin after 
Jedi "go to definition", which opens files using absolute paths.

Before this change, when using e.g. python_copy_reference#dotted()

    .Users.ben.projects.myproject.src.a.b.c

After this change:

    myproject.src.a.b.c

I found the technique on Stackoverflow [^1].

[^1]: https://stackoverflow.com/a/24463362/1396545

## Testing

Reproduce with the following steps:

1. Open vim in a top-level directory of a project.
2. Run ":e <absolute path to Python file".
3. Run e.g. python_copy_reference#dotted().