### PR TITLE
Add support for copying references to use with nose

### DIFF
--- a/plugin/python-copy-reference.vim
+++ b/plugin/python-copy-reference.vim
@@ -15,3 +15,4 @@ let g:loaded_python_copy_reference = 1
 command! -nargs=0 PythonCopyReferenceDotted call python_copy_reference#dotted()
 command! -nargs=0 PythonCopyReferencePytest call python_copy_reference#pytest()
 command! -nargs=0 PythonCopyReferenceImport call python_copy_reference#import()
+command! -nargs=0 PythonCopyReferenceNose call python_copy_reference#nose()

--- a/test/nose.vader
+++ b/test/nose.vader
@@ -1,0 +1,30 @@
+Do (copy reference):
+  :e! some/package/path.py\<cr>
+  :let g:python_copy_reference = {}\<cr>
+  :call python_copy_reference#nose()\<cr>
+
+Do (paste reference):
+  "+p
+
+Expect:
+  some.package.path
+
+Do (clean up):
+  let @+ = ''
+  :%bd!\<cr>
+
+Do (copy reference with attributes):
+  :e! some/package/path.py\<cr>
+  idef SomeClass():\<cr>  def some_function():\<cr>    pass\<esc>
+  k
+  :let g:python_copy_reference = {}\<cr>
+  :call python_copy_reference#nose()\<cr>
+
+Do (paste reference):
+  "+p
+
+Expect:
+  some.package.path:SomeClass.some_function
+
+Do (clean up):
+  :%bd!\<cr>

--- a/test/pytest.vader
+++ b/test/pytest.vader
@@ -11,3 +11,19 @@ Expect:
 
 Do (clean up):
   :%bd!\<cr>
+
+Do (copy reference with attributes):
+  :e! some/package/path.py\<cr>
+  idef SomeClass():\<cr>  def some_function():\<cr>    pass\<esc>
+  k
+  :let g:python_copy_reference = {}\<cr>
+  :call python_copy_reference#pytest()\<cr>
+
+Do (paste reference):
+  "+p
+
+Expect:
+  some/package/path.py::SomeClass::some_function
+
+Do (clean up):
+  :%bd!\<cr>


### PR DESCRIPTION
Thanks for making this convenient plugin! One of the projects I work on uses [nose](https://pypi.org/project/nose/) as its test framework, and the path format for selecting specific classes/tests to run is different from what exists in this plugin currently. Notably, nose is no longer maintained but [pynose](https://pypi.org/project/pynose/) is a drop-in replacement that supports the same format (see the `Selecting Tests` on the homepage).  

In summary, when targeting specific tests in nose, there are two path options:
1. `some.package.path:SomeClass.some_function`
2. `some/package/path.py:SomeClass.some_function`
   
I have a personal preference for option 1, but tried supporting both options to see if one was less invasive than the other. For both formats, I found that an additional separator had to be introduced, whether it was to separate the module from the attributes, or the attributes themselves.

Given this, I went with option 1. I liked the idea of refactoring `_get_attribute_parts` to `_get_attributes` which accepts a separator and returns a string, behaving similarly to `_get_module`. The alternative was to keep the logic for building the attributes string in `_get_reference` which also works, but felt a bit less elegant.

### Tests
I added `tests/nose.vader` to ensure this behaves as expected for both copying references to modules as well as attributes within a module.

I also updated the `tests/pytest.vader` to include a test for attributes as well, as it seemed like this was missing from the existing test suite since `tests/attribute.vader` only covers dotted behavior. It may be out of scope of this PR, but rather than have a separate `tests/attribute.vader` file, I think it makes sense to have an attribute test for each copy format in the relevant test file.

I've been using this locally with no issues, but mainly rely on nose and import references. If you're happy with this solution, I can also update the readme to mention this format as well.